### PR TITLE
Add option '2> /dev/null' to git describe

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -121,6 +121,7 @@ module Git
       arr_opts << "--match=#{opts[:match]}" if opts[:match]
       
       arr_opts << committish if committish
+      arr_opts << '2> /dev/null'
 
       return command('describe', arr_opts)
     end


### PR DESCRIPTION
Git describe return the tag name which could contain the warning (ex: warning: tag 'v2.10' is really '17.05.0' here). 
Adding option '2> /dev/null' which make sure no warning is added to tag name.